### PR TITLE
Update drv_pwm_output.h

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -99,7 +99,7 @@ struct pwm_output_values {
 /**
  * Highest maximum PWM in us
  */
-#define PWM_HIGHEST_MAX 2150
+#define PWM_HIGHEST_MAX 2500
 
 /**
  * Default maximum PWM in us


### PR DESCRIPTION
open highest max pwm limit from 2150 to 2500

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
servo linkages in Vtol often need further travel of the servos to cover the full tilt travel 

**Describe possible alternatives**
This extended degree of freedom should not interfere with all standard airframes as there are local and default limits.  
